### PR TITLE
refact: set container to use port 80 and non-root user

### DIFF
--- a/ForYou/angular.json
+++ b/ForYou/angular.json
@@ -70,6 +70,11 @@
           "defaultConfiguration": "production"
         },
         "serve": {
+          "options": {
+            "port": 80,
+            "host": "0.0.0.0",
+            "disableHostCheck": true
+          },
           "builder": "@angular-devkit/build-angular:dev-server",
           "configurations": {
             "production": {

--- a/ForYou/docker/Dockerfile
+++ b/ForYou/docker/Dockerfile
@@ -1,5 +1,7 @@
-FROM node:latest
+FROM node:18.1-alpine3.15
 
 WORKDIR /ForYou/
 
-RUN npm install -g @angular/cli
+USER node
+
+EXPOSE 80

--- a/ForYou/docker/docker-compose.yml
+++ b/ForYou/docker/docker-compose.yml
@@ -5,9 +5,9 @@ services:
     container_name: 'foryou'
     image: 'foryou'
     build: .
-    command: bash -c "npm install && ng serve --host=0.0.0.0 --disable-host-check"
+    command: sh -c "npm install && npm start"
     ports:
-      - "80:4200"
+      - "80:80"
     volumes:
       - ../:/ForYou
     user: "node"


### PR DESCRIPTION
Modifiquei a imagem origem do container node para o linux Alpine (Reduz consideravelmente o tamanho da imagem), removi o uso do ROOT dentro do container e setei no `angular.json` as configurações do comando `ng serve`.