### PR TITLE
feat: add lazyloading resources and create a fast splash view

### DIFF
--- a/ForYou/angular.json
+++ b/ForYou/angular.json
@@ -31,8 +31,16 @@
               "src/assets"
             ],
             "styles": [
-              "./node_modules/@angular/material/prebuilt-themes/indigo-pink.css",
-              "src/styles.scss"
+              {
+                 "input": "./node_modules/@angular/material/prebuilt-themes/indigo-pink.css",
+                 "inject": false,
+                 "bundleName": "material-indigo-pink"
+              },
+              {
+                "input": "src/styles.scss",
+                "inject": false,
+                "bundleName": "styles"
+              }
             ],
             "scripts": []
           },

--- a/ForYou/src/index.html
+++ b/ForYou/src/index.html
@@ -6,11 +6,66 @@
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
-  <link rel="preconnect" href="https://fonts.gstatic.com">
-  <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500&display=swap" rel="stylesheet">
-  <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 </head>
 <body class="mat-typography">
-  <app-root></app-root>
+  <app-root>
+    <!-- SPLASH SCREN HERE -->
+    <!-- this code will disappear after <app-root> tag is loaded -->
+    <div class="logo"></div>
+    <style>
+      body {
+        background-color: #F0C8CA;
+        width: 100vw;
+        height: 100vh;
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        align-items: center;
+      }
+      app-root {
+        width: 100%;
+        height: 100%;
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        align-items: center;
+      }
+      .logo {
+          background-image: url("assets/logo.png");
+          background-size: contain;
+          width: 100%;
+          height: 80%;
+          max-height: 450px;  /* a height less than the image resolution */
+          background-position: center;
+          background-repeat: no-repeat;
+      }
+    </style>
+    <noscript>
+      <!-- insert here for browsers with disallowed javascript execution -->
+      <p>Por favor, ative a execução de JavaScript para utilizar este site.</p>
+    </noscript>
+  </app-root>
+  <script>
+    /**
+     * Asynchronous resource loading, to speed up "First Contentful Paint"
+     **/
+    function asyncStylesheetLoader(url, rel, type) {
+      const link = document.createElement('link');
+      link.rel = rel || 'stylesheet';
+      link.href = url;
+
+      if (type) {
+        link.type = type;
+      }
+
+      document.getElementsByTagName('link')[0].parentElement.appendChild(link);
+    }
+
+    asyncStylesheetLoader('styles.css');
+    asyncStylesheetLoader('material-indigo-pink.css');
+    asyncStylesheetLoader('https://fonts.googleapis.com/icon?family=Material+Icons');
+    asyncStylesheetLoader('https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500&display=swap');
+  </script>
 </body>
 </html>


### PR DESCRIPTION
- Enquanto o browser baixa o JS com o app, o conteúdo interno da tag <app-root> será mostrado para o usuário, um splash view, acelerando o "First Contentful Paint" (Uma métrica para medir a experiência do usuário em seu site em termos de performance: o tempo para o seu site exibir um primeiro impacto na tela ao ser acessado)
- O carregamento lazyloading dos stylesheets via script permite que o site possa ser exibido enquanto as fontes e folhas de estilos são carregadas.
- Importante ter uma boa splash view, para o usuário ter paciência de esperar, caso a internet esteja lenta
- Importante ter uma mensagem pedindo para o usuário habilitar o JavaScript caso o browser tenha bloqueado seu carregamento.